### PR TITLE
iOS: requestPushAuthorization permission to read

### DIFF
--- a/ios/Classes/SwiftExponeaPlugin.swift
+++ b/ios/Classes/SwiftExponeaPlugin.swift
@@ -1403,12 +1403,39 @@ public class SwiftExponeaPlugin: NSObject, FlutterPlugin {
 
     private func requestPushAuthorization(with result: @escaping FlutterResult) {
         guard requireConfigured(with: result) else { return }
-        UNUserNotificationCenter.current().requestAuthorization(options: [.badge, .alert, .sound]) { (granted, _) in
+
+        let center = UNUserNotificationCenter.current()
+        center.getNotificationSettings { settings in
             DispatchQueue.main.async {
-                if granted {
+                switch settings.authorizationStatus {
+                case .authorized, .provisional:
+                    // Preserve original success behavior: register + true
                     UIApplication.shared.registerForRemoteNotifications()
+                    result(true)
+
+                case .notDetermined:
+                    // Preserve original request flow for first-time prompt
+                    center.requestAuthorization(options: [.badge, .alert, .sound]) { granted, _ in
+                        DispatchQueue.main.async {
+                            if granted {
+                                UIApplication.shared.registerForRemoteNotifications()
+                            }
+                            result(granted)
+                        }
+                    }
+
+                case .denied:
+                    // Preserve original "not granted" behavior
+                    result(false)
+
+                case .ephemeral:
+                    // Keep bool API semantics aligned with "authorized now"
+                    UIApplication.shared.registerForRemoteNotifications()
+                    result(true)
+
+                @unknown default:
+                    result(false)
                 }
-                result(granted)
             }
         }
     }


### PR DESCRIPTION
### Overview 

If the application had previously granted push-notification permissions prior to utilziing exponea then exponea wont read from those permissions.

- [X] Updated iOS push authorization flow to read existing notification permission state first using ``UNUserNotificationCenter.getNotificationSettings``.
- [X] Kept original method semantics (``Future<bool>`` / ``FlutterResult boolea``n):
- Returns true and registers for remote notifications when status is already .authorized or .provisional.
- Requests permission only when status is .notDetermined.
- Returns false when status is .denied.
- [X] Ensured`` UIApplication.shared.registerForRemoteNotifications()`` is called only in “granted” paths (same practical contract as before).
- [X] Added handling for ``.ephemeral`` and ``@unknown`` default to make behavior explicit and forward-safe.
- [X] Result: fixes upgrade scenario where previously granted permissions were not reliably reflected by the SDK flow, without changing the public API contract.